### PR TITLE
Basic Phoenix salt bucket functionality added

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ typeMap exists because Hive types and Phoenix types are not 1 to 1. "string|varc
 
 The "jars" property allows end-users to supply a comma separated list of jars which need to be available on the classpath of the executors (JVM libraries, etc)
 
+***Tables can be salted using the two salt properties;***
+
+<dstTableName>Salt is a number declaring the number of salt buckets to use for the table, the tablename must be all uppercased
+
+salt is a number declaring the number of salt buckets to use for any table not listed in the above property (default salt buckets)
+
 ***Saving Phoenix tables into Hive:***
 
 To query Phoenix tables and save them back to Hive, change "destination=phoenix" to "destination=hive". When saving tables to Hive, "format" specifies the intended file-format (ORC, Parquet, Avro, text, etc).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The "jars" property allows end-users to supply a comma separated list of jars wh
 
 ***Tables can be salted using the two salt properties;***
 
-<dstTableName>Salt is a number declaring the number of salt buckets to use for the table, the tablename must be all uppercased
+DST_TABLE_NAMESalt is a number declaring the number of salt buckets to use for the table, the tablename must be all uppercased
 
 salt is a number declaring the number of salt buckets to use for any table not listed in the above property (default salt buckets)
 

--- a/src/main/scala/com/github/randerzander/HiveToPhoenix.scala
+++ b/src/main/scala/com/github/randerzander/HiveToPhoenix.scala
@@ -65,9 +65,9 @@ object HiveToPhoenix{
         }
         command += " constraint my_pk primary key ("+pk+"))"
         if (props.contains(dstTables(i)+"Salt")){
-	  command += " SALT_BUCKETS = "+props.get(dstTables(i)+"Salt");
+	  command += " SALT_BUCKETS = "+props.getOrElse(dstTables(i)+"Salt","10");
 	}else if(props.contains("salt")){
-          command += " SALT_BUCKETS = "+props.get("salt");
+          command += " SALT_BUCKETS = "+props.getOrElse("salt","10");
         }
         println("INFO: DESTINATION DDL:\n" + command)
         // Execute Phoenix DDL

--- a/src/main/scala/com/github/randerzander/HiveToPhoenix.scala
+++ b/src/main/scala/com/github/randerzander/HiveToPhoenix.scala
@@ -64,6 +64,11 @@ object HiveToPhoenix{
           command += field.name + " " + dstType + ","
         }
         command += " constraint my_pk primary key ("+pk+"))"
+        if (props.contains(dstTables(i)+"Salt")){
+	  command += " SALT_BUCKETS = "+props.get(dstTables(i)+"Salt");
+	}else if(props.contains("salt")){
+          command += " SALT_BUCKETS = "+props.get("salt");
+        }
         println("INFO: DESTINATION DDL:\n" + command)
         // Execute Phoenix DDL
         getConn(jdbcClass, connStr).createStatement().execute(command)


### PR DESCRIPTION
Added the ability to add salt buckets to the Phoenix create table DDL.  The values are configurable via the properties file allowing a default, specific, or no salt buckets.
